### PR TITLE
Integrate chatbot prediction model into backend

### DIFF
--- a/BackEnd/src/chatbot/chatbot_main.py
+++ b/BackEnd/src/chatbot/chatbot_main.py
@@ -1,0 +1,91 @@
+import random
+import re
+from train_chatbot import predict_delay_from_input
+from extra_features import get_train_crowd_info, get_random_weather
+
+# Predefined intents for conversation:
+intents = {
+    "intents": [
+        {
+            "tag": "greeting",
+            "patterns": ["hello", "hi", "hey"],
+            "responses": ["Hello!", "Hi there!", "Hey! How can I assist you today?"]
+        },
+        {
+            "tag": "goodbye",
+            "patterns": ["bye", "goodbye", "see you"],
+            "responses": ["Goodbye!", "See you next time!", "Take care!"]
+        },
+        {
+            "tag": "thanks",
+            "patterns": ["thank you", "thanks", "i appreciate it"],
+            "responses": ["You're welcome!", "No problem!", "Happy to help!"]
+        },
+        {
+            "tag": "name",
+            "patterns": ["what is your name", "who are you"],
+            "responses": ["I'm your train assistant chatbot.", "Call me TrainBot."]
+        },
+        {
+            "tag": "delay_prediction",
+            "patterns": ["train delay", "will my train be late", "predict delay", "delay prediction",
+                         "what is the delay"],
+# handled dynamically by ML prediction:
+            "responses": []
+        }
+    ]
+}
+
+
+def match_intent(user_input):
+    """Match the user input to an intent tag using keyword search."""
+    user_input = user_input.lower()
+    for intent in intents["intents"]:
+        for pattern in intent["patterns"]:
+            if pattern in user_input:
+                return intent["tag"]
+    # If input mentions "delay" or "train", assume it's a delay prediction query:
+    if "delay" in user_input or "train" in user_input:
+        return "delay_prediction"
+    return "unknown"
+
+
+def generate_response(user_input):
+    """Generate a response based on the matched intent or via ML delay prediction."""
+    intent_tag = match_intent(user_input)
+
+    if intent_tag == "greeting":
+        intent_data = next(i for i in intents["intents"] if i["tag"] == "greeting")
+        response = random.choice(intent_data["responses"])
+    elif intent_tag == "goodbye":
+        intent_data = next(i for i in intents["intents"] if i["tag"] == "goodbye")
+        response = random.choice(intent_data["responses"])
+    elif intent_tag == "thanks":
+        intent_data = next(i for i in intents["intents"] if i["tag"] == "thanks")
+        response = random.choice(intent_data["responses"])
+    elif intent_tag == "name":
+        intent_data = next(i for i in intents["intents"] if i["tag"] == "name")
+        response = random.choice(intent_data["responses"])
+    elif intent_tag == "delay_prediction":
+        # generate weather once for consistency:
+        weather = get_random_weather()
+        response = predict_delay_from_input(user_input, weather)
+        # append extra advice using the same weather value:
+        extra_info = get_train_crowd_info(user_input, weather)
+        if extra_info:
+            response += "\n" + extra_info
+    else:
+        response = "Sorry, I don't understand."
+
+    return response
+
+
+if __name__ == "__main__":
+    print(" Chatbot Test Mode (type 'exit' to stop)")
+    while True:
+        user_input = input("You: ")
+        if user_input.lower() == "exit":
+            print("Bot: Goodbye!")
+            break
+        response = generate_response(user_input)
+        print(f"Bot: {response}")

--- a/BackEnd/src/chatbot/train_chatbot.py
+++ b/BackEnd/src/chatbot/train_chatbot.py
@@ -1,0 +1,115 @@
+import os
+import pickle
+import re
+import numpy as np
+from datetime import datetime
+from extra_features import get_random_weather, is_rush_hour
+
+# Dynamically resolve the absolute path to the model file
+model_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "ml_model", "model.pkl"))
+
+# Load the trained model
+with open(model_path, "rb") as file:
+    model = pickle.load(file)
+
+
+def is_peak(hour):
+    """Return 1 if the hour is in peak time, else 0."""
+    return 1 if (7 <= hour <= 10 or 16 <= hour <= 19) else 0
+
+
+# Simple station mapping (demo):
+station_to_id = {
+    "norwich": 1,
+    "london": 2,
+    "cambridge": 3,
+    "ipswich": 4,
+    "manchester": 5
+}
+
+
+def extract_features_from_input(user_input):
+    """
+    Extracts features (station deviation, day of week, hour, on-peak) from user input.
+    Expects a format like: "from London to Norwich at 12:00 on Saturday"
+    """
+    pattern = r".*from\s+([\w\s]+?)\s+to\s+([\w\s]+?)\s+at\s+(\d{1,2}:\d{2}).*on\s+(\w+).*"
+    match = re.search(pattern, user_input.lower())
+    if not match:
+        return None
+
+    origin, destination, time_str, day_str = match.groups()
+    origin = origin.strip()
+    destination = destination.strip()
+
+    try:
+        time_obj = datetime.strptime(time_str, "%H:%M")
+        hour = time_obj.hour
+    except Exception as e:
+        print(f"Time parsing error: {e}")
+        return None
+
+    day_map = {
+        "monday": 0, "tuesday": 1, "wednesday": 2, "thursday": 3,
+        "friday": 4, "saturday": 5, "sunday": 6
+    }
+    if day_str not in day_map:
+        return None
+
+    if origin not in station_to_id or destination not in station_to_id:
+        return None
+
+    origin_id = station_to_id[origin]
+    dest_id = station_to_id[destination]
+    station_deviation = abs(origin_id - dest_id)
+    day_of_week = day_map[day_str]
+    peak = is_peak(hour)
+
+    return np.array([[station_deviation, day_of_week, hour, peak]])
+
+
+def predict_delay_from_input(user_input, weather=None):
+    """
+    Extracts features from user input and uses the ML model to predict train delay.
+    Applies adjustments based on weather, rush hour, and weekend.
+    Returns the prediction in minutes and seconds.
+    """
+    features = extract_features_from_input(user_input)
+    if features is None:
+        return ("Sorry, I couldn't extract the train journey details. "
+                "Please use the format: 'from [origin] to [destination] at HH:MM on DAY'.")
+
+    # Base prediction from the model (in minutes, as a float)
+    prediction = model.predict(features)[0]
+
+    # Use provided weather or generate one
+    if weather is None:
+        weather = get_random_weather()
+
+    # Adjust prediction based on weather
+    extreme_conditions = {"heavy rain", "heavy snow", "thunderstorm", "stormy"}
+    adjustment = 0
+    if weather in extreme_conditions:
+        # Increase delay by 5 minutes for extreme weather:
+        adjustment += 5
+    elif weather in {"sunny", "clear"}:
+        # Decrease delay by 2 minutes if weather is fine:
+        adjustment -= 2
+
+    # Check for rush hour using regex on the user input:
+    time_match = re.search(r'(\d{1,2}):(\d{2})', user_input)
+    if time_match:
+        hour = int(time_match.group(1))
+        if is_rush_hour(hour):
+            # Add 3 minutes for rush hour:
+            adjustment += 3
+
+    # Check for weekend keywords in the input:
+    if "saturday" in user_input.lower() or "sunday" in user_input.lower():
+        # Add 1 minute for weekend:
+        adjustment += 1
+
+    adjusted_prediction = max(prediction + adjustment, 0)
+    minutes = int(adjusted_prediction)
+    seconds = int(round((adjusted_prediction - minutes) * 60))
+    return f"Predicted delay: {minutes} minutes and {seconds} seconds (weather: {weather})"

--- a/BackEnd/src/chatbot/train_model.py
+++ b/BackEnd/src/chatbot/train_model.py
@@ -1,0 +1,34 @@
+import pandas as pd
+import numpy as np
+import pickle
+from sklearn.model_selection import train_test_split
+from sklearn.ensemble import RandomForestRegressor
+from sklearn.metrics import mean_absolute_error
+
+# Load dataset (replace with actual train data)
+df = pd.read_csv("train_data.csv")
+
+# Feature Engineering
+df["day_of_week"] = pd.to_datetime(df["departure_time"]).dt.weekday
+df["hour"] = pd.to_datetime(df["departure_time"]).dt.hour
+df["on_peak"] = df["hour"].apply(lambda x: 1 if 7 <= x <= 9 or 17 <= x <= 19 else 0)
+
+# Define features and target variable
+features = ["station_deviation", "day_of_week", "hour", "on_peak"]
+X = df[features]
+y = df["delay_minutes"]
+
+# Split data
+X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
+
+# Train model
+model = RandomForestRegressor(n_estimators=100, random_state=42)
+model.fit(X_train, y_train)
+
+# Evaluate model
+y_pred = model.predict(X_test)
+print("MAE:", mean_absolute_error(y_test, y_pred))
+
+# Save trained model
+with open("ml_model/model.pkl", "wb") as file:
+    pickle.dump(model, file)


### PR DESCRIPTION
This pull request adds chatbot delay prediction functionality using a test RandomForest model. Files include:
- chatbot_main.py for CLI interaction
- train_model.py to generate and save the test model
- train_chatbot.py for input parsing and prediction
- chatbot_api.py (optional future step) to integrate the model as an API

These files are placed under `BackEnd/src/chatbot/`. Predictions include weather and rush hour warnings. Currently using test model, this is ready for integration with real-time frontend/backend data.
